### PR TITLE
Fix db.json loading and add Load DB import button

### DIFF
--- a/EcuTweaker/src/main/java/org/quark/dr/canapp/MainActivity.java
+++ b/EcuTweaker/src/main/java/org/quark/dr/canapp/MainActivity.java
@@ -110,6 +110,7 @@ public class MainActivity extends AppCompatActivity {
     private static final int REQUEST_CONNECT_DEVICE = 1;
     private static final int REQUEST_SCREEN = 2;
     private static final int REQUEST_ENABLE_BT = 3;
+    private static final int REQUEST_PICK_DATABASE = 4;
     @SuppressLint("StaticFieldLeak")
     public static TextView mLogView;
 
@@ -304,6 +305,9 @@ public class MainActivity extends AppCompatActivity {
 
         mChooseProjectButton.setOnClickListener(v -> chooseProject());
 
+        Button loadDbButton = findViewById(R.id.loadDbButton);
+        loadDbButton.setOnClickListener(v -> openDatabasePicker());
+
         mLinkChooser.setOnClickListener(v -> {
             if (mLinkMode == LINK_WIFI) {
                 mLinkMode = LINK_BLUETOOTH;
@@ -322,8 +326,14 @@ public class MainActivity extends AppCompatActivity {
         mEcuDatabase = new EcuDatabase();
         mEcuIdentifierNew = mEcuDatabase.new EcuIdentifierNew();
 
-        if (!askStorageReadPermission()) {
+        // Prefer already-imported app-private ecu.zip; otherwise ask storage permission
+        File appEcu = new File(getFilesDir(), "ecu.zip");
+        if (appEcu.exists() && appEcu.isFile()) {
+            mLogView.append("Found app database: " + appEcu.getAbsolutePath() + "\n");
+            parseDatabase();
+        } else if (!askStorageReadPermission()) {
             mLogView.append("You need external storage permission to read database\n");
+            mLogView.append(getString(R.string.LOAD_DATABASE_HINT) + "\n");
         }
     }
 
@@ -946,12 +956,167 @@ public class MainActivity extends AppCompatActivity {
             case REQUEST_SCREEN:
                 setConnectionStatus(STATE_DISCONNECTED);
                 break;
+            case REQUEST_PICK_DATABASE:
+                if (resultCode == Activity.RESULT_OK && data != null && data.getData() != null) {
+                    importDatabaseFromUri(data.getData());
+                }
+                break;
+        }
+    }
+
+    private void openDatabasePicker() {
+        Toast.makeText(this, getString(R.string.LOAD_DATABASE_HINT), Toast.LENGTH_LONG).show();
+        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("*/*");
+        intent.putExtra(Intent.EXTRA_MIME_TYPES, new String[]{
+                "application/zip",
+                "application/x-zip-compressed",
+                "application/octet-stream"
+        });
+        try {
+            startActivityForResult(intent, REQUEST_PICK_DATABASE);
+        } catch (ActivityNotFoundException e) {
+            // Fallback without MIME filter
+            Intent fallback = new Intent(Intent.ACTION_GET_CONTENT);
+            fallback.addCategory(Intent.CATEGORY_OPENABLE);
+            fallback.setType("*/*");
+            startActivityForResult(Intent.createChooser(fallback, getString(R.string.LOAD_DATABASE)),
+                    REQUEST_PICK_DATABASE);
+        }
+    }
+
+    private void importDatabaseFromUri(Uri uri) {
+        mStatusView.setText(getResources().getString(R.string.INDEXING_DB));
+        mLogView.append("Importing database...\n");
+        loadDbExecutor.execute(() -> {
+            String error = "";
+            String destPath = "";
+            try {
+                destPath = copyUriToAppEcuZip(uri);
+                if (!zipContainsDbJson(destPath)) {
+                    //noinspection ResultOfMethodCallIgnored
+                    new File(destPath).delete();
+                    error = getString(R.string.DATABASE_INVALID);
+                } else {
+                    // Invalidate old index so the new archive is rescanned
+                    File indexFile = new File(getFilesDir(), "ecu.idx");
+                    if (indexFile.exists()) {
+                        //noinspection ResultOfMethodCallIgnored
+                        indexFile.delete();
+                    }
+                    // Also place a copy on external storage root when possible
+                    tryCopyToExternalStorageRoot(destPath);
+                }
+            } catch (Exception e) {
+                error = e.getMessage() != null ? e.getMessage() : getString(R.string.DATABASE_IMPORT_FAILED);
+                Log.e(TAG, "Database import failed", e);
+            }
+
+            final String finalError = error;
+            final String finalPath = destPath;
+            mainHandler.post(() -> {
+                if (!finalError.isEmpty()) {
+                    mLogView.append(finalError + "\n");
+                    Toast.makeText(MainActivity.this, finalError, Toast.LENGTH_LONG).show();
+                    mStatusView.setText("ECU-TWEAKER v" + BuildConfig.VERSION_NAME);
+                    return;
+                }
+                SharedPreferences.Editor edit = defaultPrefs.edit();
+                edit.putString(PREF_ECUZIPFILE, finalPath);
+                edit.apply();
+                mLogView.append(getString(R.string.DATABASE_IMPORT_OK) + "\n");
+                mLogView.append("Path: " + finalPath + "\n");
+                Toast.makeText(MainActivity.this, R.string.DATABASE_IMPORT_OK, Toast.LENGTH_SHORT).show();
+                mEcuDatabase.unloadDatabase();
+                loadDatabaseAsync(finalPath);
+            });
+        });
+    }
+
+    private String copyUriToAppEcuZip(Uri uri) throws IOException {
+        File dest = new File(getFilesDir(), "ecu.zip");
+        File tmp = new File(getFilesDir(), "ecu.zip.tmp");
+        try (InputStream in = getContentResolver().openInputStream(uri);
+             OutputStream out = new FileOutputStream(tmp)) {
+            if (in == null) {
+                throw new IOException(getString(R.string.DATABASE_IMPORT_FAILED));
+            }
+            byte[] buffer = new byte[8192];
+            int n;
+            while ((n = in.read(buffer)) > 0) {
+                out.write(buffer, 0, n);
+            }
+            out.flush();
+        }
+        if (dest.exists() && !dest.delete()) {
+            throw new IOException("Cannot replace existing ecu.zip");
+        }
+        if (!tmp.renameTo(dest)) {
+            // renameTo can fail across mounts; fall back to copy
+            try (InputStream in = new FileInputStream(tmp);
+                 OutputStream out = new FileOutputStream(dest)) {
+                byte[] buffer = new byte[8192];
+                int n;
+                while ((n = in.read(buffer)) > 0) {
+                    out.write(buffer, 0, n);
+                }
+            }
+            //noinspection ResultOfMethodCallIgnored
+            tmp.delete();
+        }
+        return dest.getAbsolutePath();
+    }
+
+    private boolean zipContainsDbJson(String zipPath) {
+        try (java.util.zip.ZipFile zipFile = new java.util.zip.ZipFile(zipPath)) {
+            java.util.Enumeration<? extends java.util.zip.ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                java.util.zip.ZipEntry entry = entries.nextElement();
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                String name = entry.getName().replace('\\', '/');
+                int slash = name.lastIndexOf('/');
+                String base = slash >= 0 ? name.substring(slash + 1) : name;
+                if (base.equalsIgnoreCase("db.json")) {
+                    return true;
+                }
+            }
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to inspect zip", e);
+        }
+        return false;
+    }
+
+    private void tryCopyToExternalStorageRoot(String sourcePath) {
+        try {
+            File extRoot = Environment.getExternalStorageDirectory();
+            if (extRoot == null || !extRoot.exists()) {
+                return;
+            }
+            File dest = new File(extRoot, "ecu.zip");
+            try (InputStream in = new FileInputStream(sourcePath);
+                 OutputStream out = new FileOutputStream(dest)) {
+                byte[] buffer = new byte[8192];
+                int n;
+                while ((n = in.read(buffer)) > 0) {
+                    out.write(buffer, 0, n);
+                }
+            }
+            Log.i(TAG, "Also copied ecu.zip to " + dest.getAbsolutePath());
+        } catch (Exception e) {
+            // Optional convenience copy; app-private file is enough
+            Log.w(TAG, "Could not copy ecu.zip to external storage root", e);
         }
     }
 
     void parseDatabase() {
         String ecuFile = "";
-        if (defaultPrefs.contains(PREF_ECUZIPFILE)) {
+        File appEcu = new File(getFilesDir(), "ecu.zip");
+        if (appEcu.exists() && appEcu.isFile()) {
+            ecuFile = appEcu.getAbsolutePath();
+        } else if (defaultPrefs.contains(PREF_ECUZIPFILE)) {
             ecuFile = defaultPrefs.getString(PREF_ECUZIPFILE, "");
         }
         mStatusView.setText(getResources().getString(R.string.INDEXING_DB));
@@ -1275,6 +1440,8 @@ public class MainActivity extends AppCompatActivity {
             
             try {
                 String appDir = getApplicationContext().getFilesDir().getAbsolutePath();
+                // Always allow re-index after import / file replace
+                mEcuDatabase.unloadDatabase();
                 resultEcuFile = mEcuDatabase.loadDatabase(ecuFile, appDir);
                 Log.d("MainActivity", "Database loaded successfully: " + resultEcuFile);
             } catch (EcuDatabase.DatabaseException e) {

--- a/EcuTweaker/src/main/res/layout-land/content_main.xml
+++ b/EcuTweaker/src/main/res/layout-land/content_main.xml
@@ -87,6 +87,14 @@
                 app:srcCompat="@drawable/ic_bt_search"
                 tools:ignore="ContentDescription" />
 
+            <Button
+                android:id="@+id/loadDbButton"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_weight="0"
+                android:text="@string/LOAD_DATABASE"
+                android:textSize="12sp" />
+
             <ImageView
                 android:id="@+id/btIcon"
                 android:layout_width="50dp"

--- a/EcuTweaker/src/main/res/layout/content_main.xml
+++ b/EcuTweaker/src/main/res/layout/content_main.xml
@@ -96,6 +96,15 @@
                 android:layout_weight="0"
                 app:srcCompat="@drawable/ic_bt_search"
                 tools:ignore="ContentDescription" />
+
+            <Button
+                android:id="@+id/loadDbButton"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:layout_weight="0"
+                android:text="@string/LOAD_DATABASE"
+                android:textSize="10sp"
+                tools:ignore="SmallSp" />
         </LinearLayout>
 
         <LinearLayout

--- a/EcuTweaker/src/main/res/values-nl/strings.xml
+++ b/EcuTweaker/src/main/res/values-nl/strings.xml
@@ -59,4 +59,9 @@
     <string name="title_not_connected">Niet verbonden</string>
     <string name="title_other_devices">Andere beschikbare apparaten</string>
     <string name="title_paired_devices">Gepairde apparaten</string>
+    <string name="LOAD_DATABASE">Laad DB</string>
+    <string name="LOAD_DATABASE_HINT">Selecteer je DDT4All ecu.zip (of een zip met db.json). Het bestand wordt als ecu.zip in de app-map gezet.</string>
+    <string name="DATABASE_IMPORT_OK">Database geïmporteerd als ecu.zip</string>
+    <string name="DATABASE_IMPORT_FAILED">Importeren van database mislukt</string>
+    <string name="DATABASE_INVALID">Geselecteerd bestand bevat geen db.json. Exporteer de JSON-database via DDT4All.</string>
 </resources>

--- a/EcuTweaker/src/main/res/values/strings.xml
+++ b/EcuTweaker/src/main/res/values/strings.xml
@@ -68,4 +68,9 @@
     <string name="LOGFILE_DELETED">Log file successfully deleted</string>
     <string name="LOGFILE_DELETE_FAILED">Failed to delete log file</string>
     <string name="LONGPRESS_TO_DELETE">Long press to clear</string>
+    <string name="LOAD_DATABASE">Load DB</string>
+    <string name="LOAD_DATABASE_HINT">Select your DDT4All ecu.zip (or any zip containing db.json). It will be copied as ecu.zip into the app folder.</string>
+    <string name="DATABASE_IMPORT_OK">Database imported as ecu.zip</string>
+    <string name="DATABASE_IMPORT_FAILED">Failed to import database</string>
+    <string name="DATABASE_INVALID">Selected file has no db.json. Export JSON database with DDT4All.</string>
 </resources>

--- a/README.md
+++ b/README.md
@@ -161,20 +161,27 @@ The application requires the following permissions:
 
 **Important**: The ECU database (`ecu.zip`) is not included with the application.
 
-### Database Location
+### Recommended: Load DB button
 
-The app searches for `ecu.zip` in the following locations:
+1. Open the app and tap **Load DB** / **Laad DB**
+2. Select your DDT4All JSON database zip (any name is fine)
+3. The app copies it to app storage as `ecu.zip` and indexes it immediately
 
-1. Application's internal storage directory
-2. External storage root
-3. `/storage` directory
-4. `/mnt` directory
+### Manual Database Location
+
+The app also searches for `ecu.zip` in:
+
+1. Application private files directory (`files/ecu.zip`) — preferred
+2. External storage root (`/storage/emulated/0/ecu.zip`)
+3. `/storage` and `/mnt` (legacy search)
 
 ### Database Format
 
 The database is a ZIP file containing:
 - `db.json` - Main database with ECU definitions
 - Individual ECU JSON files referenced in `db.json`
+
+Generate this zip with **DDT4All** (JSON database export). Do not zip XML folders manually — that causes `db.json not found`.
 
 ## Building from Source
 

--- a/ecu/src/main/java/org/quark/dr/ecu/EcuDatabase.java
+++ b/ecu/src/main/java/org/quark/dr/ecu/EcuDatabase.java
@@ -353,15 +353,42 @@ public class EcuDatabase {
         }
     }
 
+    /**
+     * Reset loaded state so a new/updated ecu.zip can be indexed again.
+     */
+    public void unloadDatabase() {
+        m_loaded = false;
+        m_ecuFilePath = null;
+        m_zipFileSystem = null;
+        m_ecuInfo.clear();
+        m_projectSet = null;
+    }
+
     public String loadDatabase(String ecuFilename, String appDir) throws DatabaseException {
-        if (m_loaded) {
+        if (m_loaded && m_ecuFilePath != null && m_ecuFilePath.equals(ecuFilename)) {
             Log.e("EcuDatabase", "Database already loaded");
             return m_ecuFilePath;
         }
-        File checkEcuFile = new File(ecuFilename);
-        if (!checkEcuFile.exists())
-            ecuFilename = "";
+        // Allow reloading a different (or replaced) database file
+        if (m_loaded) {
+            unloadDatabase();
+        }
 
+        if (ecuFilename == null) {
+            ecuFilename = "";
+        }
+        File checkEcuFile = new File(ecuFilename);
+        if (ecuFilename.isEmpty() || !checkEcuFile.exists() || !checkEcuFile.isFile()) {
+            ecuFilename = "";
+        }
+
+        // Prefer app-private copy installed via the Load Database button
+        if (ecuFilename.isEmpty() && appDir != null) {
+            File appEcu = new File(appDir, "ecu.zip");
+            if (appEcu.exists() && appEcu.isFile()) {
+                ecuFilename = appEcu.getAbsolutePath();
+            }
+        }
         if (ecuFilename.isEmpty()) {
             ecuFilename = searchEcuFile(new File(Environment.getExternalStorageDirectory().getPath()));
         }
@@ -375,7 +402,7 @@ public class EcuDatabase {
             ecuFilename = searchEcuFile(new File("/mnt"));
         }
         if (ecuFilename.isEmpty()) {
-            throw new DatabaseException("Ecu file (ecu.zip) not found");
+            throw new DatabaseException("Ecu file (ecu.zip) not found. Use 'Load Database' to import it.");
         }
 
         String bytes;
@@ -397,19 +424,33 @@ public class EcuDatabase {
          */
         if (indexFile.exists() && (indexTimeStamp > ecuTimeStamp) && m_zipFileSystem.importZipEntries()) {
             bytes = m_zipFileSystem.getZipFile("db.json");
-            if (bytes.isEmpty()) {
-                throw new DatabaseException("Database (db.json) file not found");
+            if (bytes == null || bytes.isEmpty()) {
+                // Stale/corrupt index — rebuild
+                if (!indexFile.delete()) {
+                    Log.w("EcuDatabase", "Could not delete stale ecu.idx");
+                }
+                m_zipFileSystem = new ZipFileSystem(m_ecuFilePath, appDir);
+                m_zipFileSystem.getZipEntries();
+                m_zipFileSystem.exportZipEntries();
+                bytes = m_zipFileSystem.getZipFile("db.json");
             }
         } else {
             /*
              * Else create it
              */
+            if (indexFile.exists()) {
+                //noinspection ResultOfMethodCallIgnored
+                indexFile.delete();
+            }
             m_zipFileSystem.getZipEntries();
             m_zipFileSystem.exportZipEntries();
             bytes = m_zipFileSystem.getZipFile("db.json");
-            if (bytes.isEmpty()) {
-                throw new DatabaseException("Database (db.json) file not found");
-            }
+        }
+
+        if (bytes == null || bytes.isEmpty()) {
+            throw new DatabaseException(
+                    "Database (db.json) not found inside ecu.zip. " +
+                    "Generate ecu.zip with DDT4All (JSON database export), do not zip XML folders manually.");
         }
 
         JSONObject jsonRootObject;
@@ -419,6 +460,7 @@ public class EcuDatabase {
             throw new DatabaseException("JSON conversion issue");
         }
 
+        m_ecuInfo.clear();
         m_projectSet = new HashSet<>();
         Set<Integer> addressSet = new HashSet<>();
         Iterator<String> keys = jsonRootObject.keys();

--- a/ecu/src/main/java/org/quark/dr/ecu/ZipFileSystem.java
+++ b/ecu/src/main/java/org/quark/dr/ecu/ZipFileSystem.java
@@ -4,15 +4,20 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
 import java.util.zip.DataFormatException;
 import java.util.zip.Inflater;
 import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
 /*
@@ -23,6 +28,9 @@ import java.util.zip.ZipInputStream;
  * I can now unzip a file stored in a big zip file at the speed of light !
  * /!\ This class handles text files only
  *
+ * Falls back to java.util.zip.ZipFile when the fast path fails (STORE entries,
+ * non-standard local headers, nested paths, etc.).
+ *
  */
 
 
@@ -30,6 +38,7 @@ public class ZipFileSystem {
     private final String m_zipFilePath;
     private final String m_indexFile;
     private HashMap<String, CustomZipEntry> m_directoryEntries;
+
     public ZipFileSystem(String zipFilePath, String applicationDirectory) {
         m_directoryEntries = new HashMap<>();
         m_zipFilePath = zipFilePath;
@@ -45,9 +54,16 @@ public class ZipFileSystem {
                 ze.pos = zipEntryJson.getLong("pos");
                 ze.compressedSize = zipEntryJson.getLong("compsize");
                 ze.uncompressedSize = zipEntryJson.getLong("realsize");
-                m_directoryEntries.put(zipEntryJson.getString("name"), ze);
+                ze.method = zipEntryJson.optInt("method", ZipEntry.DEFLATED);
+                String name = normalizeEntryName(zipEntryJson.getString("name"));
+                m_directoryEntries.put(name, ze);
+                // Also keep original basename lookup
+                String base = basename(name);
+                if (!base.equals(name) && !m_directoryEntries.containsKey(base)) {
+                    m_directoryEntries.put(base, ze);
+                }
             }
-            return true;
+            return !m_directoryEntries.isEmpty();
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -58,14 +74,27 @@ public class ZipFileSystem {
     public void exportZipEntries() {
         Iterator zeit = m_directoryEntries.entrySet().iterator();
         JSONArray mainJson = new JSONArray();
+        // Export unique entries only (skip basename aliases that share the same object)
+        HashMap<CustomZipEntry, String> unique = new HashMap<>();
         while (zeit.hasNext()) {
-            HashMap.Entry pair = (HashMap.Entry) zeit.next();
+            Map.Entry pair = (Map.Entry) zeit.next();
+            CustomZipEntry cze = (CustomZipEntry) pair.getValue();
+            String name = (String) pair.getKey();
+            if (!unique.containsKey(cze) || name.indexOf('/') >= 0 || name.indexOf('\\') >= 0) {
+                // Prefer full path names over basenames
+                if (!unique.containsKey(cze) || basename((String) unique.get(cze)).equals(unique.get(cze))) {
+                    unique.put(cze, name);
+                }
+            }
+        }
+        for (Map.Entry<CustomZipEntry, String> pair : unique.entrySet()) {
             JSONObject jsonEntry = new JSONObject();
             try {
-                jsonEntry.put("pos", ((CustomZipEntry) pair.getValue()).pos);
-                jsonEntry.put("realsize", ((CustomZipEntry) pair.getValue()).uncompressedSize);
-                jsonEntry.put("compsize", ((CustomZipEntry) pair.getValue()).compressedSize);
-                jsonEntry.put("name", ((String) pair.getKey()));
+                jsonEntry.put("pos", pair.getKey().pos);
+                jsonEntry.put("realsize", pair.getKey().uncompressedSize);
+                jsonEntry.put("compsize", pair.getKey().compressedSize);
+                jsonEntry.put("method", pair.getKey().method);
+                jsonEntry.put("name", pair.getValue());
                 mainJson.put(jsonEntry);
             } catch (Exception e) {
                 e.printStackTrace();
@@ -97,15 +126,53 @@ public class ZipFileSystem {
             while ((ze = zis.getNextEntry()) != null) {
                 if (ze.isDirectory())
                     continue;
-                String filename = ze.getName();
+                String filename = normalizeEntryName(ze.getName());
                 long offset = 30 + ze.getName().length() + (ze.getExtra() != null ? ze.getExtra().length : 0);
                 pos += offset;
                 CustomZipEntry cze = new CustomZipEntry();
                 cze.pos = pos;
                 cze.compressedSize = ze.getCompressedSize();
                 cze.uncompressedSize = ze.getSize();
+                cze.method = ze.getMethod();
                 m_directoryEntries.put(filename, cze);
+                String base = basename(filename);
+                if (!base.equals(filename) && !m_directoryEntries.containsKey(base)) {
+                    m_directoryEntries.put(base, cze);
+                }
                 pos += cze.compressedSize;
+            }
+            zis.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        // If sequential scan failed or produced no entries, rebuild via ZipFile
+        if (m_directoryEntries.isEmpty()) {
+            rebuildEntriesViaZipFile();
+        }
+    }
+
+    private void rebuildEntriesViaZipFile() {
+        m_directoryEntries = new HashMap<>();
+        try (ZipFile zipFile = new ZipFile(m_zipFilePath)) {
+            java.util.Enumeration<? extends ZipEntry> entries = zipFile.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry ze = entries.nextElement();
+                if (ze.isDirectory()) {
+                    continue;
+                }
+                String filename = normalizeEntryName(ze.getName());
+                CustomZipEntry cze = new CustomZipEntry();
+                cze.pos = -1; // force ZipFile fallback for reads
+                cze.compressedSize = ze.getCompressedSize();
+                cze.uncompressedSize = ze.getSize();
+                cze.method = ze.getMethod();
+                cze.zipEntryName = ze.getName();
+                m_directoryEntries.put(filename, cze);
+                String base = basename(filename);
+                if (!base.equals(filename) && !m_directoryEntries.containsKey(base)) {
+                    m_directoryEntries.put(base, cze);
+                }
             }
         } catch (IOException e) {
             e.printStackTrace();
@@ -113,11 +180,14 @@ public class ZipFileSystem {
     }
 
     public boolean fileExists(String filename) {
-        return m_directoryEntries.containsKey(filename);
+        return resolveEntry(filename) != null;
     }
 
     public String getZipFile(String filename) {
         byte[] array = getZipFileAsBytes(filename);
+        if (array == null || array.length == 0) {
+            return "";
+        }
         try {
             return new String(array, 0, array.length, "UTF-8");
         } catch (Exception e) {
@@ -126,27 +196,151 @@ public class ZipFileSystem {
     }
 
     public byte[] getZipFileAsBytes(String filename) {
-        try {
-            long pos = m_directoryEntries.get(filename).pos;
-            long compressedSize = m_directoryEntries.get(filename).compressedSize;
-            long realSize = m_directoryEntries.get(filename).uncompressedSize;
-            byte[] array = new byte[(int) compressedSize];
-            FileInputStream zip_is = new FileInputStream(m_zipFilePath);
-            zip_is.getChannel().position(pos);
-            zip_is.read(array, 0, (int) compressedSize);
-            Inflater inflater = new Inflater(true);
-            inflater.setInput(array, 0, (int) compressedSize);
-            byte[] result = new byte[(int) realSize];
-            inflater.inflate(result);
-            inflater.end();
-            return result;
+        CustomZipEntry entry = resolveEntry(filename);
+        if (entry == null) {
+            return readViaZipFile(filename);
+        }
+
+        // Prefer reliable ZipFile path when offset is unknown or STORE
+        if (entry.pos < 0) {
+            byte[] viaZip = readViaZipFile(entry.zipEntryName != null ? entry.zipEntryName : filename);
+            if (viaZip != null) {
+                return viaZip;
+            }
+        }
+
+        if (entry.pos >= 0 && entry.compressedSize >= 0) {
+            try {
+                byte[] array = new byte[(int) entry.compressedSize];
+                FileInputStream zip_is = new FileInputStream(m_zipFilePath);
+                zip_is.getChannel().position(entry.pos);
+                int read = zip_is.read(array, 0, (int) entry.compressedSize);
+                zip_is.close();
+                if (read == entry.compressedSize) {
+                    if (entry.method == ZipEntry.STORED || entry.compressedSize == entry.uncompressedSize) {
+                        if (entry.method == ZipEntry.STORED) {
+                            return array;
+                        }
+                    }
+                    if (entry.method == ZipEntry.DEFLATED || entry.method == -1) {
+                        try {
+                            Inflater inflater = new Inflater(true);
+                            inflater.setInput(array, 0, (int) entry.compressedSize);
+                            byte[] result = new byte[(int) entry.uncompressedSize];
+                            inflater.inflate(result);
+                            inflater.end();
+                            return result;
+                        } catch (DataFormatException e) {
+                            // Fall through to ZipFile
+                        }
+                    } else if (entry.method == ZipEntry.STORED) {
+                        return array;
+                    }
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return readViaZipFile(entry.zipEntryName != null ? entry.zipEntryName : filename);
+    }
+
+    private byte[] readViaZipFile(String filename) {
+        try (ZipFile zipFile = new ZipFile(m_zipFilePath)) {
+            ZipEntry ze = findZipEntry(zipFile, filename);
+            if (ze == null) {
+                return null;
+            }
+            try (InputStream is = zipFile.getInputStream(ze);
+                 ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+                byte[] buffer = new byte[8192];
+                int n;
+                while ((n = is.read(buffer)) > 0) {
+                    bos.write(buffer, 0, n);
+                }
+                return bos.toByteArray();
+            }
         } catch (IOException e) {
             e.printStackTrace();
             return null;
-        } catch (DataFormatException e) {
-            e.printStackTrace();
+        }
+    }
+
+    private ZipEntry findZipEntry(ZipFile zipFile, String filename) {
+        if (filename == null) {
+            return null;
+        }
+        ZipEntry direct = zipFile.getEntry(filename);
+        if (direct != null) {
+            return direct;
+        }
+        String wanted = normalizeEntryName(filename).toLowerCase(Locale.ROOT);
+        String wantedBase = basename(wanted);
+        java.util.Enumeration<? extends ZipEntry> entries = zipFile.entries();
+        ZipEntry basenameMatch = null;
+        while (entries.hasMoreElements()) {
+            ZipEntry ze = entries.nextElement();
+            if (ze.isDirectory()) {
+                continue;
+            }
+            String name = normalizeEntryName(ze.getName()).toLowerCase(Locale.ROOT);
+            if (name.equals(wanted)) {
+                return ze;
+            }
+            if (basename(name).equals(wantedBase)) {
+                basenameMatch = ze;
+            }
+        }
+        return basenameMatch;
+    }
+
+    private CustomZipEntry resolveEntry(String filename) {
+        if (filename == null || m_directoryEntries == null) {
+            return null;
+        }
+        String normalized = normalizeEntryName(filename);
+        CustomZipEntry entry = m_directoryEntries.get(normalized);
+        if (entry != null) {
+            return entry;
+        }
+        entry = m_directoryEntries.get(basename(normalized));
+        if (entry != null) {
+            return entry;
+        }
+        String wanted = normalized.toLowerCase(Locale.ROOT);
+        String wantedBase = basename(wanted);
+        for (Map.Entry<String, CustomZipEntry> e : m_directoryEntries.entrySet()) {
+            String key = e.getKey().toLowerCase(Locale.ROOT);
+            if (key.equals(wanted) || basename(key).equals(wantedBase)) {
+                return e.getValue();
+            }
         }
         return null;
+    }
+
+    private static String normalizeEntryName(String name) {
+        if (name == null) {
+            return "";
+        }
+        String n = name.replace('\\', '/');
+        while (n.startsWith("./")) {
+            n = n.substring(2);
+        }
+        while (n.startsWith("/")) {
+            n = n.substring(1);
+        }
+        return n;
+    }
+
+    private static String basename(String path) {
+        if (path == null) {
+            return "";
+        }
+        int idx = path.lastIndexOf('/');
+        if (idx >= 0 && idx < path.length() - 1) {
+            return path.substring(idx + 1);
+        }
+        return path;
     }
 
     private String readFile(String file) throws IOException {
@@ -165,5 +359,7 @@ public class ZipFileSystem {
 
     static class CustomZipEntry {
         public long compressedSize, pos, uncompressedSize;
+        public int method = ZipEntry.DEFLATED;
+        public String zipEntryName;
     }
 }


### PR DESCRIPTION
## Summary
- Make ZIP/db.json reading more robust (nested paths, STORED entries, ZipFile fallback)
- Add Load DB button to import a zip and store it as ecu.zip in app storage
- Prefer app-private ecu.zip and allow database reload after import
- Improve error messages when db.json is missing from the archive

## Test plan
- [ ] Install app and tap Load DB with a valid DDT4All ecu.zip
- [ ] Verify database loads and projects appear
- [ ] Verify invalid zip shows db.json missing error